### PR TITLE
fix(screenshare): give each picker tile its own preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "packageQuick": "pnpm run build && electron-builder --dir",
         "lint": "biome check",
         "lint:fix": "biome check --write",
+        "test": "node --experimental-strip-types --import ./tests/register-ts.mjs --test tests/screenshare-previews.test.ts",
         "postinstall": "electron-builder install-app-deps",
         "CIbuild": "pnpm run build && electron-builder --linux zip && electron-builder --windows zip && electron-builder --macos zip",
         "updateMeta": "node --experimental-strip-types scripts/utils/updateMeta.ts"

--- a/src/discord/preload/bridge.ts
+++ b/src/discord/preload/bridge.ts
@@ -11,7 +11,8 @@ import type { venmicListObject } from "../venmic.js";
 interface IPCSources {
     id: string;
     name: string;
-    thumbnail: HTMLCanvasElement;
+    thumbnail: string;
+    appIcon?: string;
 }
 interface LegcordPluginInfo {
     id: string;

--- a/src/discord/screenshare.ts
+++ b/src/discord/screenshare.ts
@@ -1,5 +1,6 @@
 import { desktopCapturer, ipcMain, type Streams, session } from "electron";
 import { getConfig } from "../common/config.js";
+import { serializeCapturerSources } from "./screenshareSources.js";
 import { mainWindows } from "./window.js";
 
 export function registerCustomHandler(): void {
@@ -9,6 +10,8 @@ export function registerCustomHandler(): void {
             const sources = await desktopCapturer
                 .getSources({
                     types: ["window", "screen"],
+                    thumbnailSize: { width: 320, height: 180 },
+                    fetchWindowIcons: true,
                 })
                 .catch((err) => console.error(err));
 
@@ -46,8 +49,9 @@ export function registerCustomHandler(): void {
                     }
                 }
             });
+            const pickerSources = serializeCapturerSources(sources);
             mainWindows.every((window) => {
-                window.webContents.send("getSources", sources);
+                window.webContents.send("getSources", pickerSources);
                 return true;
             });
         },

--- a/src/discord/screenshareSources.ts
+++ b/src/discord/screenshareSources.ts
@@ -1,0 +1,99 @@
+export type NativeImageLike = {
+    toDataURL?: (type?: string) => string;
+    isEmpty?: () => boolean;
+};
+
+export type CapturerSourceLike = {
+    id: string;
+    name: string;
+    thumbnail?: NativeImageLike | string | null;
+    appIcon?: NativeImageLike | string | null;
+};
+
+export type PickerSource = {
+    id: string;
+    name: string;
+    thumbnail: string;
+    appIcon?: string;
+};
+
+function imageToDataUrl(image: NativeImageLike | string | null | undefined): string {
+    if (!image) return "";
+    if (typeof image === "string") return image;
+    try {
+        if (image.isEmpty?.()) return "";
+        const url = image.toDataURL?.();
+        return typeof url === "string" ? url : "";
+    } catch {
+        return "";
+    }
+}
+
+function hashString(value: string): number {
+    let hash = 2166136261;
+    for (let i = 0; i < value.length; i++) {
+        hash ^= value.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+    return hash >>> 0;
+}
+
+function initialsFromName(name: string): string {
+    const parts = name
+        .replace(/[()[\]{}]/g, " ")
+        .split(/\s+/)
+        .filter(Boolean);
+    if (parts.length === 0) return "?";
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return `${parts[0][0] ?? ""}${parts[1][0] ?? ""}`.toUpperCase();
+}
+
+/** Distinct, source-specific placeholder when thumbnails/icons are missing or duplicated. */
+export function fallbackSourceVisual(id: string, name: string): string {
+    const hue = hashString(id || name) % 360;
+    const initials = initialsFromName(name || id || "Source");
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180">
+<rect width="320" height="180" fill="hsl(${hue} 42% 28%)"/>
+<text x="160" y="102" text-anchor="middle" font-family="Segoe UI,sans-serif" font-size="48" font-weight="700" fill="#fff">${initials}</text>
+</svg>`;
+    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
+export function serializeCapturerSources(sources: CapturerSourceLike[]): PickerSource[] {
+    const prepared = sources.map((source) => ({
+        id: source.id,
+        name: source.name,
+        thumbnailRaw: imageToDataUrl(source.thumbnail),
+        appIcon: imageToDataUrl(source.appIcon),
+    }));
+
+    const thumbnailCounts = new Map<string, number>();
+    for (const source of prepared) {
+        if (!source.thumbnailRaw) continue;
+        thumbnailCounts.set(source.thumbnailRaw, (thumbnailCounts.get(source.thumbnailRaw) ?? 0) + 1);
+    }
+
+    const usedVisuals = new Set<string>();
+    return prepared.map((source) => {
+        const thumbnailIsDuplicate =
+            Boolean(source.thumbnailRaw) && (thumbnailCounts.get(source.thumbnailRaw) ?? 0) > 1;
+        let visual = source.thumbnailRaw;
+        if (!visual || thumbnailIsDuplicate) {
+            if (source.appIcon && !usedVisuals.has(source.appIcon)) {
+                visual = source.appIcon;
+            }
+        }
+        if (!visual || usedVisuals.has(visual)) {
+            visual = fallbackSourceVisual(source.id, source.name);
+        }
+        usedVisuals.add(visual);
+
+        const result: PickerSource = {
+            id: source.id,
+            name: source.name,
+            thumbnail: visual,
+        };
+        if (source.appIcon) result.appIcon = source.appIcon;
+        return result;
+    });
+}

--- a/src/shelter/screenshare/components/SourceCard.tsx
+++ b/src/shelter/screenshare/components/SourceCard.tsx
@@ -5,7 +5,8 @@ import classes from "./SourceCard.module.css";
 export interface IPCSources {
     id: string;
     name: string;
-    thumbnail: HTMLCanvasElement;
+    thumbnail: string;
+    appIcon?: string;
 }
 interface SourceCardProps {
     source: IPCSources;
@@ -37,7 +38,7 @@ export const SourceCard = ({ selected_name, source, onSelect }: SourceCardProps)
             </Show>
             <div class={classes.thumbnailWrapper}>
                 <img
-                    src={source.thumbnail.toDataURL()}
+                    src={source.thumbnail || source.appIcon}
                     alt={source.name}
                     class={isSelected() ? classes.thumbnailSelected : classes.thumbnailUnselected}
                 />

--- a/tests/register-ts.mjs
+++ b/tests/register-ts.mjs
@@ -1,0 +1,17 @@
+import { existsSync } from "node:fs";
+import { registerHooks } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+registerHooks({
+    resolve(specifier, context, nextResolve) {
+        if (typeof specifier === "string" && specifier.endsWith(".js") && specifier.startsWith(".")) {
+            const parent = context.parentURL ? fileURLToPath(context.parentURL) : process.cwd();
+            const tsPath = join(dirname(parent), specifier.replace(/\.js$/, ".ts"));
+            if (existsSync(tsPath)) {
+                return { url: pathToFileURL(tsPath).href, shortCircuit: true };
+            }
+        }
+        return nextResolve(specifier, context);
+    },
+});

--- a/tests/screenshare-previews.test.ts
+++ b/tests/screenshare-previews.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { serializeCapturerSources } from "../src/discord/screenshareSources.ts";
+
+function fakeImage(dataUrl: string) {
+    return {
+        toDataURL: () => dataUrl,
+        isEmpty: () => dataUrl.length === 0,
+    };
+}
+
+describe("serializeCapturerSources", () => {
+    it("gives each source a distinct usable image and keeps names", () => {
+        const sources = [
+            { id: "screen:0:0", name: "Entire screen", thumbnail: fakeImage("data:image/png;base64,SCREEN0") },
+            { id: "window:11:0", name: "Jokel Comms DOD", thumbnail: fakeImage("data:image/png;base64,JOKEL") },
+            { id: "window:22:0", name: "MSI Afterburner", thumbnail: fakeImage("data:image/png;base64,MSIAB") },
+        ];
+
+        const result = serializeCapturerSources(sources);
+        assert.equal(result.length, 3);
+        const images = result.map((source) => source.thumbnail);
+        assert.equal(new Set(images).size, 3);
+        for (const [index, source] of result.entries()) {
+            assert.equal(source.id, sources[index].id);
+            assert.equal(source.name, sources[index].name);
+            assert.ok(source.thumbnail.startsWith("data:image/"), `expected data URL for ${source.name}`);
+            assert.ok(source.thumbnail.length > "data:image/".length);
+        }
+    });
+
+    it("uses a source-specific app icon when the thumbnail is missing", () => {
+        const sources = [
+            {
+                id: "window:1:0",
+                name: "Friends List",
+                thumbnail: fakeImage(""),
+                appIcon: fakeImage("data:image/png;base64,FRIENDICON"),
+            },
+            {
+                id: "window:2:0",
+                name: "Pull requests",
+                thumbnail: fakeImage(""),
+                appIcon: fakeImage("data:image/png;base64,PRICON"),
+            },
+        ];
+
+        const result = serializeCapturerSources(sources);
+        assert.equal(result[0].name, "Friends List");
+        assert.equal(result[0].thumbnail, "data:image/png;base64,FRIENDICON");
+        assert.equal(result[1].name, "Pull requests");
+        assert.equal(result[1].thumbnail, "data:image/png;base64,PRICON");
+        assert.notEqual(result[0].thumbnail, result[1].thumbnail);
+    });
+
+    it("does not reuse a duplicated compositor thumbnail across unrelated sources", () => {
+        const sameFrame = "data:image/png;base64,SAMEFRAME";
+        const sources = [
+            { id: "screen:0:0", name: "Entire screen", thumbnail: fakeImage(sameFrame) },
+            {
+                id: "window:4432:0",
+                name: "Jokel Comms DOD",
+                thumbnail: fakeImage(sameFrame),
+                appIcon: fakeImage("data:image/png;base64,JOKELICON"),
+            },
+            { id: "window:9:0", name: "Legcord Screen Share Low FP", thumbnail: fakeImage(sameFrame) },
+        ];
+
+        const result = serializeCapturerSources(sources);
+        const images = result.map((source) => source.thumbnail);
+        assert.equal(new Set(images).size, 3);
+        assert.equal(result[1].thumbnail, "data:image/png;base64,JOKELICON");
+        for (const source of result) {
+            assert.ok(source.thumbnail.startsWith("data:image/"));
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Make the screenshare source picker show a distinct thumbnail for each window and screen instead of repeating the same compositor frame on every tile.

## Problem

`desktopCapturer.getSources()` returns Electron `NativeImage` objects. Those were sent to the renderer over IPC as-is. Structured clone does not preserve a unique bitmap per source, so the picker painted the same preview on every card. Window icons were also never requested, so missing thumbnails had nothing useful to fall back to.

## Solution

- Request 320×180 thumbnails and window icons from `desktopCapturer`
- Convert each source to a data URL in the main process before `getSources` IPC (`serializeCapturerSources`)
- If several sources share the same captured frame, use that window's app icon instead
- If there is still no unique image, use a source-specific SVG placeholder
- Source cards now take `thumbnail` / `appIcon` as strings instead of calling `toDataURL()` in the renderer

Wayland still uses the native picker. Screenshare audio is unchanged.

## Risk

Low–medium and Windows/Linux/macOS picker specific. Data-URL IPC is larger than sending `NativeImage` handles, and `fetchWindowIcons` adds a little capture work. Selecting a source and starting the stream still uses the original capturer `id`, not the serialized image.

## Testing

- [x] `pnpm lint` on the touched files
- [ ] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows
- [x] Screenshots or recordings for UI changes

`pnpm test` covers `serializeCapturerSources` (distinct frames, app-icon fallback, duplicated compositor frame).

Manually verified on Windows: each picker tile now shows that window or screen instead of a shared preview.

## AI Notice

- [x] I have used any AI/LLM tool to generate code or text in this PR. I understand that I am responsible for reviewing and validating any code generated by AI, and that I will be held accountable for any issues caused by this code.
- [ ] I have not used any AI to generate code in this PR.

## Notes

This PR is only the picker preview fix. It does not include the rich-presence or settings work from the same local tree.
