### PR TITLE
perf: use config cache in getEntireConfig IPC handler

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -113,6 +113,9 @@ export function getConfigLocation(): string {
     const storagePath = join(userDataPath, "/storage/");
     return `${storagePath}settings.json`;
 }
+export function getEntireConfig(): Settings {
+    return ensureConfigCache();
+}
 
 export function getConfig<K extends keyof Settings>(object: K): Settings[K] {
     if (process.argv.includes("--safe-mode")) {

--- a/src/discord/ipc.ts
+++ b/src/discord/ipc.ts
@@ -18,7 +18,7 @@ import {
     unblacklistGame as blacklistGameRemove,
     getBlacklist,
 } from "../common/blacklistGame.js";
-import { getConfig, getConfigLocation, setConfig, setConfigBulk } from "../common/config.js";
+import { getConfig, getConfigLocation, getEntireConfig, setConfig, setConfigBulk } from "../common/config.js";
 import { addDetectable, getDetectables, removeDetectable } from "../common/detectables.js";
 import { getLang, getLangName, getRawLang, setLang } from "../common/lang.js";
 import {
@@ -331,8 +331,7 @@ export function registerIpc(passedWindow: BrowserWindow): void {
         refreshGlobalKeybinds();
     });
     ipcMain.on("getEntireConfig", (event) => {
-        const rawData = readFileSync(getConfigLocation(), "utf-8");
-        event.returnValue = JSON.parse(rawData) as Settings;
+        event.returnValue = getEntireConfig();
     });
     ipcMain.on("getTranslations", (event) => {
         event.returnValue = getRawLang();
@@ -372,7 +371,7 @@ export function registerIpc(passedWindow: BrowserWindow): void {
         event.returnValue = os.release();
     });
     ipcMain.on("copyDebugInfo", () => {
-        const settingsFileContent = readFileSync(getConfigLocation(), "utf-8");
+        const settingsFileContent = JSON.stringify(getEntireConfig(), null, 4);
         clipboard.writeText(
             `**OS:** ${os.platform()} ${os.version()}\n**Architecture:** ${os.arch()}\n**Legcord version:** ${getVersion()}\n**Electron version:** ${
                 process.versions.electron


### PR DESCRIPTION
## Summary

Use the already-loaded config cache in `getEntireConfig` and `copyDebugInfo` IPC handlers instead of re-reading the settings file from disk on every call.

## Problem

The `getEntireConfig` IPC handler (`src/discord/ipc.ts:334`) called `readFileSync(getConfigLocation())` + `JSON.parse()` on every renderer request, even though `configCache` was already loaded in memory. The `copyDebugInfo` handler had the same issue.

## Solution

- Export `getEntireConfig()` from `config.ts` to return the cached config object via `ensureConfigCache()`
- Replace `readFileSync` + `JSON.parse` with `getEntireConfig()` in both IPC handlers
- Eliminates redundant synchronous disk I/O on every config request from the renderer

## Risk

- **Low**: `ensureConfigCache()` already handles lazy loading and error cases. The cache is kept in sync by `setConfig` and `setConfigBulk`.
- No behavioral change — same data returned, just from cache instead of disk.

## Testing

- [x] `pnpm lint` — passes cleanly
- [x] `pnpm build` — builds successfully
- [ ] Manual verification for affected flows

## AI Notice

- [x] I have used any AI/LLM tool to generate code or text in this PR. I understand that I am responsible for reviewing and validating any code generated by AI, and that I will be held accountable for any issues caused by this code.

## Notes

- Identified as critical issue #3 in the performance audit.
- The cache is invalidated on `setConfig`/`setConfigBulk` calls, so stale data is not a concern.
