### PR TITLE
fix: prevent macOS traffic lights from overlapping navigation

### DIFF
--- a/assets/app/css/darwinTitlebar.css
+++ b/assets/app/css/darwinTitlebar.css
@@ -6,6 +6,10 @@
     margin-top: 0px;
 }
 
+[legcord-platform="darwin"] div[class*="leading"]:has(+ div[class*="title"]) {
+    margin-left: 70px;
+}
+
 [legcord-platform="darwin"] #window-controls-container {
     float: left;
     width: 150px;
@@ -76,7 +80,7 @@
     display: none;
 }
 
-div[class*="bar__"][class*="hidden__"] {
+[legcord-platform="darwin"] div[class*="bar__"][class*="hidden__"] {
     pointer-events: unset;
     visibility: unset;
 }


### PR DESCRIPTION
## Summary

Prevents the native macOS traffic lights from overlapping Discord's back and forward navigation buttons.

## Problem

When using overlay chrome on macOS, Electron renders the native traffic lights over the web content. Discord's leading navigation section starts at the left edge of the window, causing its buttons to appear underneath the native window controls.

## Solution

Added a 70px left margin to Discord's leading titlebar section on macOS, reserving enough space for the native traffic lights.

The hidden titlebar override was also scoped to Darwin so it does not affect other platforms.

## Risk

This change is specific to macOS titlebar layouts.

The selector depends on Discord's generated class names containing `leading` and `title`. A future Discord layout change may require updating the selector or spacing.

## Testin

- [x] `pnpm lint`
- [ ] `pnpm build` if this PR touches runtime, bundling, or packaging code
- [x] Manual verification for affected flows
- [x] Screenshots or recordings for UI changes

## AI Notice

- [x] I have used any AI/LLM tool to generate code or text in this PR. I understand that I am responsible for reviewing and validating any code generated by AI, and that I will be held accountable for any issues caused by this code.
- [ ] I have not used any AI to generate code in this PR.

## Notes
<img width="77" height="82" alt="Captura de Tela 2026-09-05 às 02 06 26" src="https://github.com/user-attachments/assets/6efedf8e-efac-4682-8e3b-5291b6aa5159" />
<img width="79" height="75" alt="Captura de Tela 2026-09-05 às 02 06 37" src="https://github.com/user-attachments/assets/1f01d9ba-b312-4981-b015-24cddb6dcd40" />

