### PR TITLE
fix: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Adds .gitattributes with * text=auto eol=lf to enforce consistent LF line endings across all platforms.

This resolves the 199 biome formatting errors caused by core.autocrlf=true on Windows, which converts LF to CRLF on checkout, triggering biome's line-ending format checks.